### PR TITLE
feat(api/auth): patch minor issues related to update-password

### DIFF
--- a/api-server/src/modules/auth/auth.controller.ts
+++ b/api-server/src/modules/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   UseGuards,
   Request,
   Get,
+  Patch,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { UserService } from '../user/user.service';
@@ -82,7 +83,7 @@ export class AuthController {
     return res;
   }
 
-  @Post('update-password')
+  @Patch('update-password')
   @docs.updatePassword('새 비밀번호 업데이트')
   async updatePassword(
     @Body() dto: UpdatePasswordDto,

--- a/api-server/src/modules/auth/auth.docs.ts
+++ b/api-server/src/modules/auth/auth.docs.ts
@@ -90,6 +90,7 @@ export const docs: SwaggerMethodDoc<AuthController> = {
       }),
       ApiCreatedResponse({
         type: UpdatePasswordResponseDto,
+        description: 'isUpdated가 true면 성공적으로 변환, false라면 이전 비밀번호와 중복됨을 의미'
       }),
       ApiUnauthorizedResponse({ description: 'Unauthorized' })
     );

--- a/api-server/src/modules/auth/auth.service.ts
+++ b/api-server/src/modules/auth/auth.service.ts
@@ -42,6 +42,7 @@ export class AuthService {
   async sendEmail({ email, allowEmailDuplicate }: SendEmailDto): Promise<SendEmailResponseDto> {
     const user = await this.userService.findOneByEmail(email);
     if (user && !allowEmailDuplicate) return { isUserExist: true, isSend: false };
+    if (!user && allowEmailDuplicate) return { isUserExist: false, isSend: false };
 
     const verifyCode = await this.verifyCodeRepository.findOne({ email });
 

--- a/api-server/src/modules/auth/auth.service.ts
+++ b/api-server/src/modules/auth/auth.service.ts
@@ -157,9 +157,16 @@ export class AuthService {
         HttpStatus.BAD_REQUEST,
       );
     }
+    const isEqual = await this.passwordHasher.equal({
+      plain: newPassword,
+      hashed: user.password,
+    })
+    if (isEqual) {
+      return { isUpdated: false }
+    }
     await this.userRepository.update(user, {
       password: await this.passwordHasher.hash(newPassword),
     });
-    return { isOk: true };
+    return { isUpdated: true };
   }
 }

--- a/api-server/src/modules/auth/dto/update-password.dto.ts
+++ b/api-server/src/modules/auth/dto/update-password.dto.ts
@@ -14,5 +14,5 @@ export class UpdatePasswordDto {
 export class UpdatePasswordResponseDto {
   @IsBoolean()
   @ApiProperty()
-  isOk: boolean;
+  isUpdated: boolean;
 }


### PR DESCRIPTION
비밀번호 변경과 관련한 마이너 이슈를 해결합니다.
- update-password : POST -> PATCH로 변경. 이전의 비밀번호와 동일할 때 `isUpdated = false` 리턴
- send-email: 요청 body의 `allowEmailDuplicate` 가  `true`일 때(= 비밀번호 변경을 위한 인증번호 요청일 때), DB에 없는  이메일로 요청 시 실패 메시지 반환