### PR TITLE
fix(api): fix foreign key issues that occur when deleting user

### DIFF
--- a/api-server/src/entities/abuse-report.entity.ts
+++ b/api-server/src/entities/abuse-report.entity.ts
@@ -47,7 +47,7 @@ export class AbuseReport {
   })
   status: Status;
 
-  @ManyToOne(() => User, (user) => user.abusereports)
+  @ManyToOne(() => User, (user) => user.abusereports, { onDelete: 'SET NULL' })
   user: User;
 
   @ApiProperty({ type: Number })

--- a/api-server/src/entities/comment.entity.ts
+++ b/api-server/src/entities/comment.entity.ts
@@ -57,6 +57,6 @@ export class Comment {
   @RelationId((comment: Comment) => comment.parent)
   parentId?: number;
 
-  @OneToMany(() => Comment, (comment) => comment.parent, { cascade: true })
+  @OneToMany(() => Comment, (comment) => comment.parent)
   children: Comment[];
 }

--- a/api-server/src/entities/comment.entity.ts
+++ b/api-server/src/entities/comment.entity.ts
@@ -20,10 +20,10 @@ export class Comment {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => Review, (review) => review.comments)
+  @ManyToOne(() => Review, (review) => review.comments, { onDelete: 'SET NULL' })
   review: Promise<Review>;
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { onDelete: 'SET NULL' })
   user: User;
 
   @ApiProperty({ type: Number })
@@ -49,7 +49,7 @@ export class Comment {
   /**
    * 답글
    */
-  @ManyToOne(() => Comment)
+  @ManyToOne(() => Comment, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'parentId', referencedColumnName: 'id' })
   parent?: Comment;
 
@@ -57,6 +57,6 @@ export class Comment {
   @RelationId((comment: Comment) => comment.parent)
   parentId?: number;
 
-  @OneToMany(() => Comment, (comment) => comment.parent)
+  @OneToMany(() => Comment, (comment) => comment.parent, { cascade: true })
   children: Comment[];
 }

--- a/api-server/src/entities/hit.entity.ts
+++ b/api-server/src/entities/hit.entity.ts
@@ -28,6 +28,6 @@ export class Hit {
   /**
    * relation
    */
-  @ManyToOne(() => User, (user) => user.hits)
+  @ManyToOne(() => User, (user) => user.hits, { onDelete: 'SET NULL' })
   user: User;
 }

--- a/api-server/src/entities/review-likes.entity.ts
+++ b/api-server/src/entities/review-likes.entity.ts
@@ -25,12 +25,12 @@ export class ReviewLike {
   /**
    * relation
    */
-  @ManyToOne(() => User, (user) => user.reviewLikes)
+  @ManyToOne(() => User, (user) => user.reviewLikes, { onDelete: 'SET NULL' })
   user: User;
 
   /**
    * relation
    */
-  @ManyToOne(() => Review, (review) => review.likes)
+  @ManyToOne(() => Review, (review) => review.likes, { onDelete: 'SET NULL' })
   review: Review;
 }

--- a/api-server/src/entities/review.entity.ts
+++ b/api-server/src/entities/review.entity.ts
@@ -45,7 +45,7 @@ export class Review {
   })
   hashtags: Hashtag[];
 
-  @ManyToOne(() => User, (user) => user.reviews)
+  @ManyToOne(() => User, (user) => user.reviews, { onDelete: 'SET NULL' })
   user: User;
 
   @ManyToOne(() => App, (app) => app.reviews)

--- a/api-server/src/migrations/1639132994392-UpdateForeignKeyToSetNull.ts
+++ b/api-server/src/migrations/1639132994392-UpdateForeignKeyToSetNull.ts
@@ -1,0 +1,43 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class UpdateForeignKeyToSetNull1639132994392 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`production\`.\`abuse_report\` DROP FOREIGN KEY \`FK_ed232e88d60a0d539b600431d57\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review\` DROP FOREIGN KEY \`FK_81446f2ee100305f42645d4d6c2\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_likes\` DROP FOREIGN KEY \`FK_3cd606c64c23bfb2e8634f91b69\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_likes\` DROP FOREIGN KEY \`FK_eeb9d9410f16e3b743bd3c9b007\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` DROP FOREIGN KEY \`FK_25d65c01e1b3192c934c2469b77\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` DROP FOREIGN KEY \`FK_d00ccfa77fcc9b25fcf9b9b50c1\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` DROP FOREIGN KEY \`FK_16cc302113c3fd00d930056fa38\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`hit\` DROP FOREIGN KEY \`FK_b31ef5cca03f9a14652d0e5c9c7\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`hit\` ADD CONSTRAINT \`FK_b31ef5cca03f9a14652d0e5c9c7\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` ADD CONSTRAINT \`FK_16cc302113c3fd00d930056fa38\` FOREIGN KEY (\`review_id\`) REFERENCES \`production\`.\`review\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` ADD CONSTRAINT \`FK_d00ccfa77fcc9b25fcf9b9b50c1\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` ADD CONSTRAINT \`FK_25d65c01e1b3192c934c2469b77\` FOREIGN KEY (\`parentId\`) REFERENCES \`production\`.\`review_comments\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_likes\` ADD CONSTRAINT \`FK_eeb9d9410f16e3b743bd3c9b007\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_likes\` ADD CONSTRAINT \`FK_3cd606c64c23bfb2e8634f91b69\` FOREIGN KEY (\`review_id\`) REFERENCES \`production\`.\`review\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review\` ADD CONSTRAINT \`FK_81446f2ee100305f42645d4d6c2\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`abuse_report\` ADD CONSTRAINT \`FK_ed232e88d60a0d539b600431d57\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`production\`.\`abuse_report\` DROP FOREIGN KEY \`FK_ed232e88d60a0d539b600431d57\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review\` DROP FOREIGN KEY \`FK_81446f2ee100305f42645d4d6c2\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_likes\` DROP FOREIGN KEY \`FK_3cd606c64c23bfb2e8634f91b69\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_likes\` DROP FOREIGN KEY \`FK_eeb9d9410f16e3b743bd3c9b007\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` DROP FOREIGN KEY \`FK_25d65c01e1b3192c934c2469b77\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` DROP FOREIGN KEY \`FK_d00ccfa77fcc9b25fcf9b9b50c1\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` DROP FOREIGN KEY \`FK_16cc302113c3fd00d930056fa38\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`hit\` DROP FOREIGN KEY \`FK_b31ef5cca03f9a14652d0e5c9c7\``);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`hit\` ADD CONSTRAINT \`FK_b31ef5cca03f9a14652d0e5c9c7\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` ADD CONSTRAINT \`FK_16cc302113c3fd00d930056fa38\` FOREIGN KEY (\`review_id\`) REFERENCES \`production\`.\`review\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` ADD CONSTRAINT \`FK_d00ccfa77fcc9b25fcf9b9b50c1\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_comments\` ADD CONSTRAINT \`FK_25d65c01e1b3192c934c2469b77\` FOREIGN KEY (\`parentId\`) REFERENCES \`production\`.\`review_comments\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_likes\` ADD CONSTRAINT \`FK_eeb9d9410f16e3b743bd3c9b007\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review_likes\` ADD CONSTRAINT \`FK_3cd606c64c23bfb2e8634f91b69\` FOREIGN KEY (\`review_id\`) REFERENCES \`production\`.\`review\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`review\` ADD CONSTRAINT \`FK_81446f2ee100305f42645d4d6c2\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`production\`.\`abuse_report\` ADD CONSTRAINT \`FK_ed232e88d60a0d539b600431d57\` FOREIGN KEY (\`user_id\`) REFERENCES \`production\`.\`user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/api-server/src/modules/auth/auth.module.ts
+++ b/api-server/src/modules/auth/auth.module.ts
@@ -8,6 +8,8 @@ import { AuthService } from './auth.service';
 import { VerifyCode } from '../../entities/verify-code.entity';
 import { User } from '../../entities/user.entity';
 import { UserModule } from '../user/user.module';
+import { Comment } from '../../entities/comment.entity';
+import { Review } from '../../entities/review.entity';
 import { PasswordHasher } from './password-hasher';
 import { UserService } from '../user/user.service';
 import { MailSender } from './mail-sender';
@@ -19,7 +21,7 @@ import { LocalStrategy } from './strategy/local.strategy';
     UserModule,
     ConfigModule,
     PassportModule,
-    TypeOrmModule.forFeature([VerifyCode, User]),
+    TypeOrmModule.forFeature([VerifyCode, User, Comment, Review]),
     JwtModule.registerAsync({
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => {

--- a/api-server/src/modules/user/user.module.ts
+++ b/api-server/src/modules/user/user.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../../entities/user.entity';
+import { Comment } from '../../entities/comment.entity';
+import { Review } from '../../entities/review.entity';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, Comment, Review])],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/api-server/src/modules/user/user.service.ts
+++ b/api-server/src/modules/user/user.service.ts
@@ -2,6 +2,8 @@ import { Repository } from 'typeorm';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../../entities/user.entity';
+import { Comment } from '../../entities/comment.entity';
+import { Review } from '../../entities/review.entity';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { CreateUserDto } from './dto/create-user.dto';
 import { DeleteUserResponseDto } from './dto/delete-user.dto';
@@ -11,6 +13,10 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private usersRepository: Repository<User>,
+    @InjectRepository(Comment)
+    private commentRepository: Repository<Comment>,
+    @InjectRepository(Review)
+    private reviewRepository: Repository<Review>,
   ) {}
 
   async createUser(data: CreateUserDto): Promise<User> {
@@ -48,6 +54,11 @@ export class UserService {
   }
 
   async deleteUserById(id: number): Promise<DeleteUserResponseDto> {
+    const user = await this.usersRepository.findOne(id);
+    const comments = await this.commentRepository.find({ where: { user: user } });
+    const reviews = await this.reviewRepository.find({ where: { user: user } });
+    await this.commentRepository.softRemove(comments);
+    await this.reviewRepository.softRemove(reviews);
     await this.usersRepository.delete(id);
     return { isDelete: true };
   }


### PR DESCRIPTION
유저를 삭제할 때 외래키 관련해서 500에러가 나는 버그를 해결합니다.

원래 `CASCADE`로 일괄 삭제를 하려 했는데, 현재 리뷰랑 코멘트 단에서 soft delete를 사용하고 있고 또 정책이 확정된 건 아니지만 추후 활용을 위해 데이터들은 남아 있어야 할 것 같아 리뷰랑 코멘트는 soft delete로 삭제하고 나머지 테이블들은 `SET NULL`로 유저 정보만 빼기로 했습니다.

다만 개인적인 생각이라 다른 의견 있으시면 말씀해주세요!