### PR TITLE
feat(api): filter search results that invalid for reporting

### DIFF
--- a/api-server/src/entities/comment.entity.ts
+++ b/api-server/src/entities/comment.entity.ts
@@ -35,6 +35,10 @@ export class Comment {
   content: string;
 
   @ApiProperty()
+  @Column({ default: '' })
+  reportUserIds: string;
+
+  @ApiProperty()
   @CreateDateColumn()
   createdAt: Date;
 

--- a/api-server/src/entities/review.entity.ts
+++ b/api-server/src/entities/review.entity.ts
@@ -39,6 +39,10 @@ export class Review {
   })
   hole: Hole;
 
+  @ApiProperty()
+  @Column({ default: '' })
+  reportUserIds: string;
+
   @ManyToMany(() => Hashtag, (hashtag) => hashtag.reviews)
   @JoinTable({
     name: 'review_hashtags',

--- a/api-server/src/migrations/1640026371494-AddReportUserIdsToReviewAndComment.ts
+++ b/api-server/src/migrations/1640026371494-AddReportUserIdsToReviewAndComment.ts
@@ -1,0 +1,23 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddReportUserIdsToReviewAndComment1640026371494 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE \`production\`.\`review\` ADD \`report_user_ids\` varchar(255) NOT NULL DEFAULT ''`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE \`production\`.\`review_comments\` ADD \`report_user_ids\` varchar(255) NOT NULL DEFAULT ''`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE \`production\`.\`review\` DROP COLUMN \`report_user_ids\``,
+        );
+        await queryRunner.query(
+            `ALTER TABLE \`production\`.\`review_comments\` DROP COLUMN \`report_user_ids\``,
+        );
+    }
+
+}

--- a/api-server/src/modules/abusereport/abuse-report.controller.ts
+++ b/api-server/src/modules/abusereport/abuse-report.controller.ts
@@ -52,9 +52,10 @@ export class AbuseReportController {
   }
 
   @Get(':id')
+  @UseGuards(JwtAuthGuard)
   @docs.findOne('단일 신고 조회')
-  async findOne(@Param('id') id: string) {
-    return await this.abusereportService.findOne(+id);
+  async findOne(@Request() req: AuthorizedRequest, @Param('id') id: string) {
+    return await this.abusereportService.findOne(req.user, +id);
   }
 
   @Patch(':id')

--- a/api-server/src/modules/abusereport/abuse-report.controller.ts
+++ b/api-server/src/modules/abusereport/abuse-report.controller.ts
@@ -64,8 +64,12 @@ export class AbuseReportController {
   }
 
   @Delete(':id')
+  @UseGuards(JwtAuthGuard)
   @docs.remove('신고 삭제')
-  async remove(@Param('id') id: string) {
-    return await this.abusereportService.remove(+id);
+  async remove(
+    @Request() req: AuthorizedRequest,
+    @Param('id') id: string,
+  ) {
+    return await this.abusereportService.remove(req.user, +id);
   }
 }

--- a/api-server/src/modules/abusereport/abuse-report.service.ts
+++ b/api-server/src/modules/abusereport/abuse-report.service.ts
@@ -1,10 +1,10 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateAbuseReportDto } from './dto/create-abuse-report.dto';
 import { ReviewService } from '../review/review.service';
 import { CommentsService } from '../comments/comments.service';
-import { AbuseReport, Status } from '../../entities/abuse-report.entity';
+import { AbuseReport, AbuseType, Status } from '../../entities/abuse-report.entity';
 import { User } from '../../entities/user.entity';
 
 @Injectable()
@@ -21,6 +21,19 @@ export class AbuseReportService {
     createabuseReportDto: CreateAbuseReportDto,
   ): Promise<AbuseReport> {
     const { type, targetId } = createabuseReportDto;
+
+    const _abuseReport = await this.abuseReportRepository.findOne({ user, type, targetId });
+    if (_abuseReport) throw new BadRequestException('this abuse report is already exist');
+
+    if (type === AbuseType.Review) {
+      const review = await this.reviewService.findOne(targetId);
+      if (!review) throw new NotFoundException();
+      await this.reviewService.upsertReportUserIds(review.id, user.id);
+    } else if (type === AbuseType.Reply) {
+      const comment = await this.commentService.findOne(targetId);
+      if (!comment) throw new NotFoundException();
+      await this.commentService.upsertReportUserIds(comment.id, user.id);
+    }
 
     const abuseReport = this.abuseReportRepository.create({
       user,
@@ -59,10 +72,20 @@ export class AbuseReportService {
     return await this.abuseReportRepository.save(abuseReport);
   }
 
-  async remove(id: number): Promise<void> {
+  async remove(user: User, id: number): Promise<void> {
     const abuseReport = await this.abuseReportRepository.findOne(id);
     if (!abuseReport) {
       throw new NotFoundException();
+    }
+
+    if (abuseReport.type === AbuseType.Review) {
+      const review = await this.reviewService.findOne(abuseReport.targetId);
+      if (!review) throw new NotFoundException();
+      await this.reviewService.deleteReportUserIds(review.id, user.id);
+    } else if (abuseReport.type === AbuseType.Reply) {
+      const comment = await this.commentService.findOne(abuseReport.targetId);
+      if (!comment) throw new NotFoundException();
+      await this.commentService.deleteReportUserIds(comment.id, user.id);
     }
 
     await this.abuseReportRepository.remove(abuseReport);

--- a/api-server/src/modules/abusereport/abuse-report.service.ts
+++ b/api-server/src/modules/abusereport/abuse-report.service.ts
@@ -26,7 +26,7 @@ export class AbuseReportService {
     if (_abuseReport) throw new BadRequestException('this abuse report is already exist');
 
     if (type === AbuseType.Review) {
-      const review = await this.reviewService.findOne(targetId);
+      const review = await this.reviewService.findOne(targetId, user);
       if (!review) throw new NotFoundException();
       await this.reviewService.upsertReportUserIds(review.id, user.id);
     } else if (type === AbuseType.Reply) {
@@ -49,13 +49,13 @@ export class AbuseReportService {
     return this.abuseReportRepository.find();
   }
 
-  async findOne(id: number) {
+  async findOne(user: User, id: number) {
     const abuseReport = await this.abuseReportRepository.findOne(id);
     if (!abuseReport) {
       throw new NotFoundException();
     }
     if (abuseReport.type === 'review') {
-      const review = this.reviewService.findOne(abuseReport.targetId);
+      const review = this.reviewService.findOne(abuseReport.targetId, user);
       return { ...abuseReport, review };
     } else if (abuseReport.type === 'comment') {
       const comment = this.commentService.findOne(abuseReport.targetId);
@@ -79,7 +79,7 @@ export class AbuseReportService {
     }
 
     if (abuseReport.type === AbuseType.Review) {
-      const review = await this.reviewService.findOne(abuseReport.targetId);
+      const review = await this.reviewService.findOne(abuseReport.targetId, user);
       if (!review) throw new NotFoundException();
       await this.reviewService.deleteReportUserIds(review.id, user.id);
     } else if (abuseReport.type === AbuseType.Reply) {

--- a/api-server/src/modules/comments/comments.controller.ts
+++ b/api-server/src/modules/comments/comments.controller.ts
@@ -21,8 +21,9 @@ export class CommentsController {
 
   @docs.findAll('댓글 목록 조회')
   @Get(':review_id')
-  findAll(@Param('review_id', ParseIntPipe) id: number) {
-    return this.commentsService.findAll(id);
+  @UseGuards(JwtAuthGuard)
+  findAll(@Request() req: AuthorizedRequest, @Param('review_id', ParseIntPipe) id: number) {
+    return this.commentsService.findAll(req.user, id);
   }
 
   @docs.update('댓글 수정')

--- a/api-server/src/modules/comments/comments.service.ts
+++ b/api-server/src/modules/comments/comments.service.ts
@@ -29,7 +29,7 @@ export class CommentsService {
 
     let review = null;
     if (reviewId) {
-      review = await this.reviewService.findOne(reviewId);
+      review = await this.reviewService.findOne(reviewId, user);
     }
 
     let parent = null;
@@ -48,7 +48,7 @@ export class CommentsService {
     return comment;
   }
 
-  async findAll(reviewId: number): Promise<Comment[]> {
+  async findAll({ id: userId }: User, reviewId: number): Promise<Comment[]> {
 
     const comment = await this.commentRepository
       .createQueryBuilder('comments')
@@ -61,6 +61,8 @@ export class CommentsService {
       .where('comments.review=:reviewId',{reviewId})
       .andWhere('comments.parentId is null')
       .loadRelationCountAndMap('comments.childrenCount','comments.children')
+      .andWhere('FIND_IN_SET(:userId, comments.report_user_ids) = 0', { userId })
+      .andWhere('LENGTH(comments.report_user_ids) - LENGTH(REPLACE(comments.report_user_ids, ",", "")) < 4')
       .getMany()
 
       return comment;

--- a/api-server/src/modules/comments/comments.service.ts
+++ b/api-server/src/modules/comments/comments.service.ts
@@ -112,4 +112,33 @@ export class CommentsService {
     }
     return { isDeleted: true };
   }
+
+  async upsertReportUserIds(id: number, userId: number): Promise<void> {
+    const review = await this.commentRepository.findOne(id);
+    if (!review) throw new NotFoundException();
+
+    if (review.reportUserIds === '') {
+      await this.commentRepository.save({ ...review, reportUserIds: userId.toString() });
+    } else {
+      const reportUserIdList = review.reportUserIds.split(',');
+      if (reportUserIdList.findIndex((v) => Number(v) === userId) !== -1) return;
+      await this.commentRepository.save({
+        ...review,
+        reportUserIds: reportUserIdList.concat(userId.toString()).join(','),
+      });
+    }
+  }
+
+  async deleteReportUserIds(id: number, userId: number): Promise<void> {
+    const review = await this.commentRepository.findOne(id);
+    if (!review) throw new NotFoundException();
+
+    if (review.reportUserIds !== '') {
+      const reportUserIdList = review.reportUserIds.split(',');
+      await this.commentRepository.save({
+        ...review,
+        reportUserIds: reportUserIdList.filter((v) => v !== userId.toString()).join(','),
+      });
+    }
+  }
 }

--- a/api-server/src/modules/review/review.controller.ts
+++ b/api-server/src/modules/review/review.controller.ts
@@ -34,9 +34,10 @@ export class ReviewController {
   }
 
   @Get(':id')
+  @UseGuards(JwtAuthGuard)
   @docs.findOne('단일 리뷰 조회')
-  async findOne(@Param('id') id: string) {
-    return await this.reviewService.findOne(+id);
+  async findOne(@Param('id') id: string, @AuthUser() user: JwtUser) {
+    return await this.reviewService.findOne(+id, user);
   }
 
   @Patch(':id')

--- a/api-server/src/modules/review/review.service.ts
+++ b/api-server/src/modules/review/review.service.ts
@@ -178,4 +178,33 @@ export class ReviewService {
       throw new ForbiddenException(`No alreadylike`);
     }
   }
+
+  async upsertReportUserIds(id: number, userId: number): Promise<void> {
+    const review = await this.reviewRepository.findOne(id);
+    if (!review) throw new NotFoundException();
+
+    if (review.reportUserIds === '') {
+      await this.reviewRepository.save({ ...review, reportUserIds: userId.toString() });
+    } else {
+      const reportUserIdList = review.reportUserIds.split(',');
+      if (reportUserIdList.findIndex((v) => Number(v) === userId) !== -1) return;
+      await this.reviewRepository.save({
+        ...review,
+        reportUserIds: reportUserIdList.concat(userId.toString()).join(','),
+      });
+    }
+  }
+
+  async deleteReportUserIds(id: number, userId: number): Promise<void> {
+    const review = await this.reviewRepository.findOne(id);
+    if (!review) throw new NotFoundException();
+
+    if (review.reportUserIds !== '') {
+      const reportUserIdList = review.reportUserIds.split(',');
+      await this.reviewRepository.save({
+        ...review,
+        reportUserIds: reportUserIdList.filter((v) => v !== userId.toString()).join(','),
+      });
+    }
+  }
 }

--- a/api-server/src/modules/review/review.service.ts
+++ b/api-server/src/modules/review/review.service.ts
@@ -60,7 +60,7 @@ export class ReviewService {
     return this.reviewRepository.find();
   }
 
-  async findOne(id: number): Promise<Review> {
+  async findOne(id: number, { id: userId }: JwtUser): Promise<Review> {
     if (isNaN(id)) {
       throw new BadRequestException();
     }
@@ -82,7 +82,13 @@ export class ReviewService {
       .leftJoinAndSelect('review.hashtags', 'hashtags')
       .leftJoinAndSelect('review.likes', 'likes')
       .leftJoinAndSelect('review.user', 'user')
-      .leftJoinAndSelect('review.comments', 'comments')
+      .leftJoinAndSelect(
+        'review.comments',
+        'comments',
+        `FIND_IN_SET(:userId, comments.report_user_ids) = 0
+          AND LENGTH(comments.report_user_ids) - LENGTH(REPLACE(comments.report_user_ids, ",", "")) < 4`,
+        { userId },
+      )
       .leftJoin('comments.user', 'comment_user')
       .leftJoin('likes.user', 'like_user')
       .leftJoinAndSelect('comments.children', 'children')

--- a/api-server/src/modules/search/search.controller.ts
+++ b/api-server/src/modules/search/search.controller.ts
@@ -4,9 +4,13 @@ import {
   Get,
   ParseIntPipe,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { Pagination } from 'nestjs-typeorm-paginate';
+import { AuthUser } from 'src/core/decorators/auth-user.decorator';
 import { Hole, Review } from 'src/entities/review.entity';
+import { JwtUser } from 'src/entities/user.entity';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { SearchService } from './search.service';
 import { docs } from './search.docs';
 import { ApiTags } from '@nestjs/swagger';
@@ -18,14 +22,17 @@ export class SearchController {
   constructor(private readonly searchService: SearchService) {}
 
   @Get('review')
+  @UseGuards(JwtAuthGuard)
   @docs.searchReview('리뷰 피드 요청 API')
   async searchReview(
+    @AuthUser() user: JwtUser,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit = 10,
     @Query('userId') userId?: string,
     @Query('hole') hole?: Hole,
   ): Promise<Pagination<Review>> {
     return await this.searchService.searchReview(
+      user,
       { page, limit },
       { userId, hole },
     );


### PR DESCRIPTION
신고 횟수, 신고한 유저에 따라 리뷰와 댓글을 숨김 처리하는 로직을 추가합니다.
이번에 추가된 로직은 아래와 같습니다.

1. 리뷰, 댓글 테이블에 신고한 유저들의 id를 확인할 수 있는 `reportUserIds` 컬럼 추가 (이때 `reportUserIds` 타입은 string이며 `1,2,123`과 같이 따옴표로 구분합니다.)
2. 신고가 접수되면 신고 컨텐츠(리뷰, 댓글)의 `reportUserIds` 에 신고한 유저 id를 추가합니다.
3. 클라이언트에 결과를 내려줄 때 현재 로그인한 유저가 신고를 한 컨텐츠이거나, 신고 횟수가 총 5회 이상인 경우는 제외합니다.
4. 신고가 삭제될 경우 신고 컨텐츠(리뷰, 댓글)의 `reportUserIds` 에서 신고한 유저 id를 제거합니다.

3번을 작업하다보니 쿼리 로직이 많이 길어지게 되어 가독성 및 성능 저하의 우려가 있는데, 이 부분은 의견 공유해주시면 감사하겠습니다.